### PR TITLE
Fix trivial typo

### DIFF
--- a/initial-slides.md
+++ b/initial-slides.md
@@ -6,7 +6,7 @@
 
 ## The Basics
 
-- Seperate slides using '`---`' on a blank line
+- Separate slides using '`---`' on a blank line
 - Write github flavored markdown
 - Click 'Present' (top right) when you're ready to talk
 


### PR DESCRIPTION
Separate is spelled this way, so I thought I'd submit a pull request. Hope that's OK.

I remember this lucidly because I once got this wrong in a spelling bee.